### PR TITLE
Add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+[![npm govuk_template_mustache](http://img.shields.io/npm/v/govuk_template_mustache.svg)](https://www.npmjs.org/package/govuk_template_mustache)
+
+# {{ mustache }} version of the GOV.UK template
+
+This repository is the [{{ mustache }}][mustache] version of the [govuk_template][].
+
+It's published to the [npm Registry][govuk_template_mustache_npm] and you can add it to your application's dependencies from there.
+
+## Build
+
+This repo is automatically built from the [govuk_template][] when the version number is changed in that repository. Please don't send pull requests here for anything but this README, send them to [govuk_template][] instead. They'll end up here when the template is updated.
+
+## Examples
+
+- [The Performance Platform frontend][perfplat] is [a Node.js application][spotlight] that uses this version of the GOV.UK template installed from npm
+
+[mustache]: https://mustache.github.io/
+[govuk_template]: https://github.com/alphagov/govuk_template
+[govuk_template_mustache_npm]: https://www.npmjs.org/package/govuk_template_mustache
+[perfplat]: https://www.gov.uk/performance
+[spotlight]: https://github.com/alphagov/spotlight


### PR DESCRIPTION
Closes #2.

See also alphagov/govuk_template#74 for some changes that will improve how this package looks on the npm Registry.
